### PR TITLE
Fixed incorrect syntax in files

### DIFF
--- a/phase3testcases/ifStmtReturns.jott
+++ b/phase3testcases/ifStmtReturns.jott
@@ -12,6 +12,6 @@ Def foo[]:Integer{
     }
 }
 
-def main[]:Void{
+Def main[]:Void{
     ::foo[];
 }

--- a/phase3testcases/mismatchedReturn.jott
+++ b/phase3testcases/mismatchedReturn.jott
@@ -5,7 +5,7 @@ Def foo[y:Integer]:Double{
 	Return 3.3;
 }
 
-def main[]:Void{
+Def main[]:Void{
     Integer x;
     x = ::foo[5];
 	::print[x];

--- a/phase3testcases/validLoop.jott
+++ b/phase3testcases/validLoop.jott
@@ -4,7 +4,7 @@ Def foo[x:Integer]:Integer{
     Return x + 1;
 }
 
-def main[]:Void{
+Def main[]:Void{
     Integer x;
     x = 0;
 	While[x<10]{

--- a/phase3testcases/whileKeyword.jott
+++ b/phase3testcases/whileKeyword.jott
@@ -1,10 +1,9 @@
 #should pass phase 2 but fail phase 3
-#while is a keyword and starts with an uppercase letter
 
 Def foo[]:Void{
-    Integer While;
-    While = 5;
-	::print[While];
+    Integer hile;
+    hile = 5;
+	::print[hile];
 }
 
-Def main[]:void{}
+Def main[]:Void{}


### PR DESCRIPTION
Incorrect syntax in files caused tester to stop before testing semantic analysis, corrected the syntax 